### PR TITLE
Add extra mxsettings options

### DIFF
--- a/pilatusApp/Db/pilatus.template
+++ b/pilatusApp/Db/pilatus.template
@@ -420,6 +420,16 @@ record(ao, "$(P)$(R)Phi")
     field(EGU,  "deg")
 }
 
+record(ao, "$(P)$(R)PhiIncr")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHI_INCR")
+    field(PREC, "4")
+    field(VAL,  "0.1")
+    field(EGU,  "deg")
+}
+
 record(ao, "$(P)$(R)Chi")
 {
     field(PINI, "YES")
@@ -427,6 +437,36 @@ record(ao, "$(P)$(R)Chi")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CHI")
     field(PREC, "4")
     field(VAL,  "0")
+    field(EGU,  "deg")
+}
+
+record(ao, "$(P)$(R)ChiIncr")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CHI_INCR")
+    field(PREC, "4")
+    field(VAL,  "0.1")
+    field(EGU,  "deg")
+}
+
+record(ao, "$(P)$(R)Omega")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OMEGA")
+    field(PREC, "4")
+    field(VAL,  "0")
+    field(EGU,  "deg")
+}
+
+record(ao, "$(P)$(R)OmegaIncr")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OMEGA_INCR")
+    field(PREC, "4")
+    field(VAL,  "0.1")
     field(EGU,  "deg")
 }
 

--- a/pilatusApp/src/pilatusDetector.cpp
+++ b/pilatusApp/src/pilatusDetector.cpp
@@ -99,7 +99,11 @@ static const char *driverName = "pilatusDetector";
 #define PilatusAlphaString          "ALPHA"
 #define PilatusKappaString          "KAPPA"
 #define PilatusPhiString            "PHI"
+#define PilatusPhiIncrString        "PHI_INCR"
 #define PilatusChiString            "CHI"
+#define PilatusChiIncrString        "CHI_INCR"
+#define PilatusOmegaString          "OMEGA"
+#define PilatusOmegaIncrString      "OMEGA_INCR"
 #define PilatusOscillAxisString     "OSCILL_AXIS"
 #define PilatusNumOscillString      "NUM_OSCILL"
 #define PilatusPixelCutOffString    "PIXEL_CUTOFF"
@@ -161,7 +165,11 @@ protected:
     int PilatusAlpha;
     int PilatusKappa;
     int PilatusPhi;
+    int PilatusPhiIncr;
     int PilatusChi;
+    int PilatusChiIncr;
+    int PilatusOmega;
+    int PilatusOmegaIncr;
     int PilatusOscillAxis;
     int PilatusNumOscill;
     int PilatusPixelCutOff;  
@@ -1472,8 +1480,20 @@ asynStatus pilatusDetector::writeFloat64(asynUser *pasynUser, epicsFloat64 value
     } else if (function == PilatusPhi) {
         epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Phi %f", value);
         writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
+    } else if (function == PilatusPhiIncr) {
+        epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Phi_increment %f", value);
+        writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
     } else if (function == PilatusChi) {
         epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Chi %f", value);
+        writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
+    } else if (function == PilatusChiIncr) {
+        epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Chi_increment %f", value);
+        writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
+    } else if (function == PilatusOmega) {
+        epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Omega %f", value);
+        writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
+    } else if (function == PilatusOmegaIncr) {
+        epicsSnprintf(this->toCamserver, sizeof(this->toCamserver), "mxsettings Omega_increment %f", value);
         writeReadCamserver(CAMSERVER_DEFAULT_TIMEOUT);
     } else {
         /* If this parameter belongs to a base class call its method */
@@ -1667,7 +1687,11 @@ pilatusDetector::pilatusDetector(const char *portName, const char *camserverPort
     createParam(PilatusAlphaString,          asynParamFloat64, &PilatusAlpha);
     createParam(PilatusKappaString,          asynParamFloat64, &PilatusKappa);
     createParam(PilatusPhiString,            asynParamFloat64, &PilatusPhi);
+    createParam(PilatusPhiIncrString,        asynParamFloat64, &PilatusPhiIncr);
     createParam(PilatusChiString,            asynParamFloat64, &PilatusChi);
+    createParam(PilatusChiIncrString,        asynParamFloat64, &PilatusChiIncr);
+    createParam(PilatusOmegaString,          asynParamFloat64, &PilatusOmega);
+    createParam(PilatusOmegaIncrString,      asynParamFloat64, &PilatusOmegaIncr);
     createParam(PilatusOscillAxisString,     asynParamOctet,   &PilatusOscillAxis);
     createParam(PilatusNumOscillString,      asynParamInt32,   &PilatusNumOscill);
     createParam(PilatusPixelCutOffString,    asynParamInt32,   &PilatusPixelCutOff);


### PR DESCRIPTION
Patches to add mxsettings options not available in the upstream driver.
It is a single commit. The text of the commit message follows.

The list of mxsettings is shown on page 34 of the
pilatus 2 user manual revision 1.5 dated 8 August 2014
commit message in dls subversion repo
r91666 | ajf67 | 2013-03-25 15:02:00 +0000 (Mon, 25 Mar 2013) | 5 lines
support: pilatusADDriver: Add new records: PhiIncr, ChiIncr, Omega and OmegaIncr
to "pilatus.template" to agree with new camserver version: tvx-7.3.13-121212b.