### PR TITLE
Move array counter increment to before set of NDArray UniqueID

### DIFF
--- a/pilatusApp/src/pilatusDetector.cpp
+++ b/pilatusApp/src/pilatusDetector.cpp
@@ -1202,6 +1202,14 @@ void pilatusDetector::pilatusTask()
                     continue;
                 }
 
+                /* We successfully read an image - increment the array counter */
+                getIntegerParam(NDArrayCounter, &imageCounter);
+                imageCounter++;
+                setIntegerParam(NDArrayCounter, imageCounter);
+                /* Call the callbacks to update any changes */
+                callParamCallbacks();
+
+                /* Now assemble the NDArray */
                 getIntegerParam(PilatusFlatFieldValid, &flatFieldValid);
                 if (flatFieldValid) {
                     epicsInt32 *pData, *pFlat;
@@ -1220,12 +1228,6 @@ void pilatusDetector::pilatusTask()
                 /* Get any attributes that have been defined for this driver */        
                 this->getAttributes(pImage->pAttributeList);
                 
-                getIntegerParam(NDArrayCounter, &imageCounter);
-                imageCounter++;
-                setIntegerParam(NDArrayCounter, imageCounter);
-                /* Call the callbacks to update any changes */
-                callParamCallbacks();
-
                 /* Call the NDArray callback */
                 asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
                      "%s:%s: calling NDArray callback\n", driverName, functionName);


### PR DESCRIPTION
This fixes a problem we had at DLS where the UniqueID on the first NDArray of an acquisition was the last of the previous acquisition, which did not play nicely with the Pos plugin.

It looks like this was broken in 138558e2929dcc6a73b59403ec664a2d09c1c998 to fix a problem where NDArrayCounter was incremented when an image was not successfully processed. This should behave correctly for both cases now.