### PR TITLE
Update timestamp from epics inside while(acquire) loop

### DIFF
--- a/pilatusApp/src/pilatusDetector.cpp
+++ b/pilatusApp/src/pilatusDetector.cpp
@@ -1184,6 +1184,9 @@ void pilatusDetector::pilatusTask()
             getIntegerParam(NDArrayCallbacks, &arrayCallbacks);
 
             if (arrayCallbacks) {
+                // get the start time from EPICS for each frame
+                epicsTimeGetCurrent(&startTime);
+
                 /* Get an image buffer from the pool */
                 getIntegerParam(ADMaxSizeX, &itemp); dims[0] = itemp;
                 getIntegerParam(ADMaxSizeY, &itemp); dims[1] = itemp;

--- a/pilatusApp/src/pilatusDetector.cpp
+++ b/pilatusApp/src/pilatusDetector.cpp
@@ -1225,7 +1225,7 @@ void pilatusDetector::pilatusTask()
                 /* Put the frame number and time stamp into the buffer */
                 pImage->uniqueId = imageCounter;
                 updateTimeStamp(&pImage->epicsTS);
-                pImage->timeStamp = pImage->epicsTs.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
+                pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
                 /* Get any attributes that have been defined for this driver */        
                 this->getAttributes(pImage->pAttributeList);

--- a/pilatusApp/src/pilatusDetector.cpp
+++ b/pilatusApp/src/pilatusDetector.cpp
@@ -1184,9 +1184,6 @@ void pilatusDetector::pilatusTask()
             getIntegerParam(NDArrayCallbacks, &arrayCallbacks);
 
             if (arrayCallbacks) {
-                // get the start time from EPICS for each frame
-                epicsTimeGetCurrent(&startTime);
-
                 /* Get an image buffer from the pool */
                 getIntegerParam(ADMaxSizeX, &itemp); dims[0] = itemp;
                 getIntegerParam(ADMaxSizeY, &itemp); dims[1] = itemp;
@@ -1227,8 +1224,8 @@ void pilatusDetector::pilatusTask()
                 } 
                 /* Put the frame number and time stamp into the buffer */
                 pImage->uniqueId = imageCounter;
-                pImage->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
                 updateTimeStamp(&pImage->epicsTS);
+                pImage->timeStamp = pImage->epicsTs.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
                 /* Get any attributes that have been defined for this driver */        
                 this->getAttributes(pImage->pAttributeList);


### PR DESCRIPTION
Previously noticed that all frames have identical timestamps, the startTime timestamp only gets updated in the first while loop, so within while (acquire) block timestamps are currently the same if collecting more than a single frame. 

e: after discussing with @coretl I will push again to this so that the timestamp uses EpicsTS, as the two timestamps are currently separated by some lines of code.